### PR TITLE
Remove unexpected ';' in cart-empy.blade.php

### DIFF
--- a/resources/views/woocommerce/cart/cart-empty.blade.php
+++ b/resources/views/woocommerce/cart/cart-empty.blade.php
@@ -10,7 +10,7 @@ wc_print_notices();
 @endphp
 <div class="sw-cart__empty flex-column">
 
-	@php(do_action( 'woocommerce_cart_is_empty' );)
+	@php(do_action( 'woocommerce_cart_is_empty' ))
 
 	@if ( wc_get_page_id( 'shop' ) > 0 )
 		<p class="return-to-shop">


### PR DESCRIPTION
Fix error if the cart is empty

Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Parse error: syntax error, unexpected ';' in 