### PR TITLE
Update soberwp/controller version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "composer/installers": "~1.0",
     "illuminate/support": "~5.4",
     "roots/sage-lib": "~9.0.0-beta.4",
-    "soberwp/controller": "2.0.0"
+    "soberwp/controller": "~9.0.0-beta.4"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "composer/installers": "~1.0",
     "illuminate/support": "~5.4",
     "roots/sage-lib": "~9.0.0-beta.4",
-    "soberwp/controller": "~9.0.0-beta.4"
+    "soberwp/controller": "~2.0.1",
+    "symfony/yaml": "^3.2"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8.0",


### PR DESCRIPTION
If I try to use `App:title()` or another controller function an error appears:

`Class 'App' not found in`

Only changed 

`"soberwp/controller": "2.0.0"`
to
`"soberwp/controller": "~9.0.0-beta.4"`


